### PR TITLE
Use defaults in kernel config for any new params

### DIFF
--- a/devsus.sh
+++ b/devsus.sh
@@ -50,6 +50,7 @@ AWK=gawk sh ../deblob-3.14 --force
 export WIFIVERSION=-3.8
 ./chromeos/scripts/prepareconfig chromiumos-rockchip
 cp ../config .config
+make olddefconfig
 make -j `grep ^processor /proc/cpuinfo  | wc -l` CROSS_COMPILE=arm-none-eabi- ARCH=arm zImage modules dtbs
 [ ! -h kernel.its ] && ln -s ../kernel.its .
 mkimage -D "-I dts -O dtb -p 2048" -f kernel.its vmlinux.uimg


### PR DESCRIPTION
Currently, the build interactively asks for two new kernel config options - using the defaults would make sure, the build can progress without pausing and waiting user input, in case upstream introduces new configuration options.